### PR TITLE
Scaffold chrome extension and set up manifest

### DIFF
--- a/icons/.gitkeep
+++ b/icons/.gitkeep
@@ -1,0 +1,23 @@
+# Icons Directory
+
+This directory contains the extension icons in different sizes:
+
+- icon16.png - 16x16 pixels (toolbar icon)
+- icon48.png - 48x48 pixels (extension management page)
+- icon128.png - 128x128 pixels (Chrome Web Store)
+
+## Placeholder Icons
+
+Currently using placeholder descriptions. Replace with actual PNG files:
+
+**icon16.png**: 16x16 pixel icon for the browser toolbar
+**icon48.png**: 48x48 pixel icon for the extensions management page
+**icon128.png**: 128x128 pixel icon for the Chrome Web Store listing
+
+## Design Guidelines
+
+- Use a consistent color scheme that matches the extension's branding
+- Ensure icons are recognizable at small sizes
+- Consider using a shield or privacy-related symbol
+- Follow Chrome Web Store icon guidelines
+- Use PNG format with transparency if needed

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 3,
+  "name": "SimpleTerms",
+  "version": "1.0",
+  "description": "AI-powered privacy policy summarizer that provides instant summaries and risk scores",
+  "action": {
+    "default_popup": "popup/popup.html",
+    "default_title": "SimpleTerms - Analyze Privacy Policy"
+  },
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "storage"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["scripts/content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "background": {
+    "service_worker": "scripts/background.js"
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "host_permissions": [
+    "<all_urls>"
+  ]
+}

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,0 +1,199 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #333;
+    line-height: 1.6;
+}
+
+.main-container {
+    width: 350px;
+    padding: 20px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    text-align: center;
+}
+
+h1 {
+    color: #2c3e50;
+    font-size: 24px;
+    font-weight: 700;
+    margin-bottom: 5px;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.subtitle {
+    color: #7f8c8d;
+    font-size: 14px;
+    margin-bottom: 20px;
+    font-weight: 500;
+}
+
+.analyze-btn {
+    width: 100%;
+    padding: 12px 20px;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 20px;
+}
+
+.analyze-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+}
+
+.analyze-btn:active {
+    transform: translateY(0);
+}
+
+.analyze-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.btn-icon {
+    font-size: 18px;
+}
+
+.results-container {
+    text-align: left;
+    min-height: 50px;
+}
+
+.loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #667eea;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.score-container {
+    background: #f8f9fa;
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 15px;
+    text-align: center;
+}
+
+.score-label {
+    font-size: 14px;
+    color: #6c757d;
+    margin-bottom: 8px;
+    font-weight: 500;
+}
+
+.score-value {
+    font-size: 24px;
+    font-weight: 700;
+    margin-bottom: 5px;
+}
+
+.score-description {
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.score-low {
+    color: #28a745;
+}
+
+.score-medium {
+    color: #ffc107;
+}
+
+.score-high {
+    color: #dc3545;
+}
+
+.summary-container {
+    background: #f8f9fa;
+    border-radius: 8px;
+    padding: 15px;
+}
+
+.summary-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 10px;
+}
+
+.summary-list {
+    list-style: none;
+    padding: 0;
+}
+
+.summary-list li {
+    padding: 8px 0;
+    border-bottom: 1px solid #e9ecef;
+    font-size: 14px;
+    color: #495057;
+    position: relative;
+    padding-left: 20px;
+}
+
+.summary-list li:last-child {
+    border-bottom: none;
+}
+
+.summary-list li::before {
+    content: "•";
+    color: #667eea;
+    font-weight: 700;
+    position: absolute;
+    left: 0;
+}
+
+.error-message {
+    background: #f8d7da;
+    color: #721c24;
+    padding: 12px;
+    border-radius: 8px;
+    font-size: 14px;
+    text-align: center;
+    border: 1px solid #f5c6cb;
+}
+
+.no-policy-message {
+    background: #fff3cd;
+    color: #856404;
+    padding: 12px;
+    border-radius: 8px;
+    font-size: 14px;
+    text-align: center;
+    border: 1px solid #ffeaa7;
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SimpleTerms</title>
+    <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+    <div class="main-container">
+        <h1>SimpleTerms</h1>
+        <p class="subtitle">AI Privacy Policy Analyzer</p>
+        <button id="analyzeButton" class="analyze-btn">
+            <span class="btn-icon">🔍</span>
+            Analyze Policy
+        </button>
+        <div id="resultsContainer" class="results-container">
+            <!-- Results will be dynamically inserted here -->
+        </div>
+    </div>
+    <script src="popup.js"></script>
+</body>
+</html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,0 +1,159 @@
+// SimpleTerms Popup JavaScript
+document.addEventListener('DOMContentLoaded', function() {
+    const analyzeButton = document.getElementById('analyzeButton');
+    const resultsContainer = document.getElementById('resultsContainer');
+
+    // Add event listener to the analyze button
+    analyzeButton.addEventListener('click', async function() {
+        try {
+            // Disable button and show loading state
+            analyzeButton.disabled = true;
+            analyzeButton.textContent = 'Analyzing...';
+            showLoading();
+
+            // Get the active tab
+            const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+            
+            // Inject and execute the content script
+            await chrome.scripting.executeScript({
+                target: { tabId: tab.id },
+                files: ['scripts/content.js']
+            });
+
+        } catch (error) {
+            console.error('Error executing content script:', error);
+            showError('Failed to analyze the page. Please try again.');
+            resetButton();
+        }
+    });
+
+    // Listen for messages from content script
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        if (message.type === 'POLICY_URL_FOUND') {
+            handlePolicyFound(message.url);
+        } else if (message.type === 'NO_POLICY_FOUND') {
+            handleNoPolicyFound();
+        } else if (message.type === 'ERROR') {
+            showError(message.error);
+            resetButton();
+        }
+    });
+
+    function showLoading() {
+        resultsContainer.innerHTML = `
+            <div class="loading">
+                <div class="spinner"></div>
+            </div>
+        `;
+    }
+
+    function showError(message) {
+        resultsContainer.innerHTML = `
+            <div class="error-message">
+                <strong>Error:</strong> ${message}
+            </div>
+        `;
+    }
+
+    function handleNoPolicyFound() {
+        resultsContainer.innerHTML = `
+            <div class="no-policy-message">
+                <strong>No Privacy Policy Found</strong><br>
+                This page doesn't appear to have a privacy policy link.
+            </div>
+        `;
+        resetButton();
+    }
+
+    async function handlePolicyFound(policyUrl) {
+        try {
+            // Fetch the privacy policy content
+            const response = await fetch(policyUrl);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch policy: ${response.status}`);
+            }
+
+            const html = await response.text();
+            const policyText = extractTextFromHTML(html);
+
+            // TODO: Send to AI backend for analysis
+            // For now, show a placeholder result
+            showMockResults(policyUrl);
+
+        } catch (error) {
+            console.error('Error fetching policy:', error);
+            showError('Failed to fetch the privacy policy. The link might be broken or require authentication.');
+            resetButton();
+        }
+    }
+
+    function extractTextFromHTML(html) {
+        // Create a temporary DOM element to parse HTML
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = html;
+
+        // Remove script and style elements
+        const scripts = tempDiv.querySelectorAll('script, style, nav, header, footer');
+        scripts.forEach(el => el.remove());
+
+        // Get text content and clean it up
+        let text = tempDiv.textContent || tempDiv.innerText || '';
+        
+        // Clean up whitespace
+        text = text.replace(/\s+/g, ' ').trim();
+        
+        return text;
+    }
+
+    function showMockResults(policyUrl) {
+        // Mock results for demonstration (will be replaced with real AI analysis)
+        const mockScore = Math.floor(Math.random() * 10) + 1;
+        const mockSummary = [
+            "Collects personal information including name, email, and browsing data",
+            "Uses data for service improvement and targeted advertising",
+            "Shares information with third-party partners and advertisers",
+            "Data may be transferred internationally",
+            "Users can request data deletion but some information may be retained"
+        ];
+
+        displayResults(mockScore, mockSummary, policyUrl);
+        resetButton();
+    }
+
+    function displayResults(score, summary, policyUrl) {
+        let scoreClass = 'score-low';
+        let scoreDescription = 'Low Risk';
+        
+        if (score >= 4 && score <= 6) {
+            scoreClass = 'score-medium';
+            scoreDescription = 'Medium Risk';
+        } else if (score >= 7) {
+            scoreClass = 'score-high';
+            scoreDescription = 'High Risk';
+        }
+
+        const summaryHtml = summary.map(point => `<li>${point}</li>`).join('');
+
+        resultsContainer.innerHTML = `
+            <div class="score-container">
+                <div class="score-label">Privacy Risk Score</div>
+                <div class="score-value ${scoreClass}">${score}/10</div>
+                <div class="score-description ${scoreClass}">${scoreDescription}</div>
+            </div>
+            <div class="summary-container">
+                <div class="summary-title">Key Points:</div>
+                <ul class="summary-list">
+                    ${summaryHtml}
+                </ul>
+            </div>
+            <div style="margin-top: 10px; font-size: 12px; color: #6c757d; text-align: center;">
+                Analyzed: <a href="${policyUrl}" target="_blank" style="color: #667eea;">Privacy Policy</a>
+            </div>
+        `;
+    }
+
+    function resetButton() {
+        analyzeButton.disabled = false;
+        analyzeButton.innerHTML = '<span class="btn-icon">🔍</span>Analyze Policy';
+    }
+});

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,0 +1,71 @@
+// SimpleTerms Background Script (Service Worker)
+// Handles background tasks and extension lifecycle events
+
+chrome.runtime.onInstalled.addListener((details) => {
+    console.log('SimpleTerms extension installed/updated:', details.reason);
+    
+    if (details.reason === 'install') {
+        // Initialize storage with default values
+        chrome.storage.local.set({
+            summaryCount: 0,
+            installDate: Date.now(),
+            version: chrome.runtime.getManifest().version
+        });
+        
+        console.log('SimpleTerms: Extension installed successfully');
+    } else if (details.reason === 'update') {
+        console.log('SimpleTerms: Extension updated to version', chrome.runtime.getManifest().version);
+    }
+});
+
+// Handle extension startup
+chrome.runtime.onStartup.addListener(() => {
+    console.log('SimpleTerms: Extension started');
+});
+
+// Handle messages from content scripts and popup
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log('SimpleTerms: Background received message:', message.type);
+    
+    switch (message.type) {
+        case 'GET_STORAGE_DATA':
+            // Return storage data to requesting script
+            chrome.storage.local.get(null, (data) => {
+                sendResponse(data);
+            });
+            return true; // Keep the message channel open for async response
+            
+        case 'UPDATE_SUMMARY_COUNT':
+            // Increment the summary count
+            chrome.storage.local.get(['summaryCount'], (data) => {
+                const newCount = (data.summaryCount || 0) + 1;
+                chrome.storage.local.set({ summaryCount: newCount }, () => {
+                    sendResponse({ summaryCount: newCount });
+                });
+            });
+            return true;
+            
+        case 'RESET_SUMMARY_COUNT':
+            // Reset summary count (for premium users)
+            chrome.storage.local.set({ summaryCount: 0 }, () => {
+                sendResponse({ success: true });
+            });
+            return true;
+            
+        default:
+            console.log('SimpleTerms: Unknown message type:', message.type);
+    }
+});
+
+// Handle extension icon click (optional - popup handles most interactions)
+chrome.action.onClicked.addListener((tab) => {
+    console.log('SimpleTerms: Extension icon clicked on tab:', tab.url);
+    // The popup will handle the interaction
+});
+
+// Cleanup function for when extension is disabled/uninstalled
+chrome.runtime.onSuspend.addListener(() => {
+    console.log('SimpleTerms: Extension is being suspended');
+});
+
+console.log('SimpleTerms: Background script loaded successfully');

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,0 +1,99 @@
+// SimpleTerms Content Script
+// This script runs on all web pages to detect privacy policy links
+
+(function() {
+    'use strict';
+
+    // Prioritized array of regex patterns to find privacy policy links
+    const privacyPatterns = [
+        /privacy[-_]?policy/i,
+        /privacy[-_]?statement/i,
+        /privacy[-_]?notice/i,
+        /data[-_]?protection/i,
+        /privacy/i,
+        /terms[-_]?of[-_]?service/i,
+        /terms[-_]?and[-_]?conditions/i,
+        /terms[-_]?of[-_]?use/i,
+        /legal/i,
+        /gdpr/i
+    ];
+
+    function findPrivacyPolicyLink() {
+        try {
+            // Get all anchor tags on the page
+            const links = document.querySelectorAll('a[href]');
+            const candidates = [];
+
+            // Score each link based on how well it matches our patterns
+            links.forEach(link => {
+                const href = link.href.toLowerCase();
+                const text = (link.textContent || '').toLowerCase().trim();
+                const title = (link.title || '').toLowerCase();
+                
+                // Skip mailto, tel, and javascript links
+                if (href.startsWith('mailto:') || href.startsWith('tel:') || href.startsWith('javascript:')) {
+                    return;
+                }
+
+                // Check URL, text content, and title against patterns
+                const urlMatches = privacyPatterns.some(pattern => pattern.test(href));
+                const textMatches = privacyPatterns.some(pattern => pattern.test(text));
+                const titleMatches = privacyPatterns.some(pattern => pattern.test(title));
+
+                if (urlMatches || textMatches || titleMatches) {
+                    let score = 0;
+                    
+                    // Higher score for URL matches (most reliable)
+                    if (urlMatches) score += 10;
+                    if (textMatches) score += 5;
+                    if (titleMatches) score += 3;
+                    
+                    // Bonus for exact matches
+                    if (href.includes('privacy-policy') || href.includes('privacy_policy')) score += 15;
+                    if (text.includes('privacy policy')) score += 10;
+                    
+                    // Penalty for terms-only matches (less specific)
+                    if (href.includes('terms') && !href.includes('privacy')) score -= 5;
+                    
+                    candidates.push({
+                        url: link.href,
+                        text: text,
+                        score: score,
+                        element: link
+                    });
+                }
+            });
+
+            // Sort by score and return the best match
+            candidates.sort((a, b) => b.score - a.score);
+            
+            if (candidates.length > 0) {
+                const bestMatch = candidates[0];
+                console.log('SimpleTerms: Found privacy policy link:', bestMatch.url);
+                
+                // Send the URL to the popup
+                chrome.runtime.sendMessage({
+                    type: 'POLICY_URL_FOUND',
+                    url: bestMatch.url,
+                    text: bestMatch.text,
+                    score: bestMatch.score
+                });
+            } else {
+                console.log('SimpleTerms: No privacy policy link found');
+                chrome.runtime.sendMessage({
+                    type: 'NO_POLICY_FOUND'
+                });
+            }
+
+        } catch (error) {
+            console.error('SimpleTerms: Error finding privacy policy link:', error);
+            chrome.runtime.sendMessage({
+                type: 'ERROR',
+                error: 'Failed to scan page for privacy policy links'
+            });
+        }
+    }
+
+    // Execute the search
+    findPrivacyPolicyLink();
+})();


### PR DESCRIPTION
Add initial scaffolding for the SimpleTerms Chrome extension, including manifest, popup UI, and core scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-961b28f8-3c1d-490a-bf38-8b57d0b9d0f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-961b28f8-3c1d-490a-bf38-8b57d0b9d0f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

